### PR TITLE
Updated autoconf instructions in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,13 +111,10 @@ work together, but with cccl you can make them become reluctant friends.
 
 Autoconf requires a file called *configure.ac*, which on legacy projects may
 still be called *configure.in*.  In order to use autoconf and MSVC, make sure 
-the following lines are in your *configure.ac* file:
+the following line is in your *configure.ac* file:
 
 ```
-AC_CANONICAL_SYSTEM
-AC_CYGWIN
-AC_OBJEXT
-AC_EXEEXT
+AC_CANONICAL_HOST
 ```
 
 If your *configure.ac* file contains a reference to `AM_PROG_LIBTOOL`, add the


### PR DESCRIPTION
The autoconf instructions reference the following obsolete macros:
* `AC_CANONICAL_SYSTEM` is obsolete and should be replaced with `AC_CANONICAL_HOST`
* `AC_CYGWIN` is obsolete, superseded by `AC_CANONICAL_HOST`
* `AC_OBJEXT` and `AC_EXEEXT` are obsolete

Replaced the lot with just `AC_CANONICAL_HOST`