### PR TITLE
Add "dumpmachine"/"dumpmachinefull" arguments to get the target machine triplet ("dumpmachinefull" for the full MSVC version). 

### DIFF
--- a/cccl
+++ b/cccl
@@ -39,25 +39,40 @@ case $MACHTYPE in
         ;;
 esac
 
+# Process the "dumpmachine"/"dumpmachinefull" arguments first, if they exist, and exit gracefully
 for arg in $@; do
-    if [ "$arg" == "-dumpmachine" ] || [ "$arg" == "-dumpmachinefull" ]; then
-        cmd_out="$(cl 2>&1)"
-        cmd_out_parts=($cmd_out)
+    if [[ $arg =~ ^-dumpmachine(full)?$ ]]; then
+        cl_output_parts=($(cl 2>&1))
+
         msvc="msvc"
         if [ "$arg" == "-dumpmachinefull" ]; then
-            msvc="$msvc${cmd_out_parts[6]}"
+            msvc="$msvc${cl_output_parts[6]}"
         fi
-        arch="$(echo ${cmd_out_parts[8]} | awk '{print tolower($0)}')"
+
+        arch="$(echo ${cl_output_parts[8]} | awk '{print tolower($0)}')"
         output="pc-windows-$msvc"
-        if [ "$arch" = "x64" ]; then
+        case $arch in
+
+        x64)
             output="x86_64-$output"
-        elif [ "$arch" = "x86" ]; then
+            ;;
+
+        # "file" command, with "libmagic", shows "Intel 80386" for "X86" architecture
+        x86)
             output="i386-$output"
-        elif [ "$arch" = "arm64" ]; then
+            ;;
+
+        arm64)
             output="aarch64-$output"
-        else
+            ;;
+
+        # "file" command, with "libmagic", shows "ARMv7" for "ARM" architecture
+        arm)
             output="armv7-$output"
-        fi
+            ;;
+
+        esac
+
         echo $output
         exit 0
     fi

--- a/cccl
+++ b/cccl
@@ -39,6 +39,30 @@ case $MACHTYPE in
         ;;
 esac
 
+for arg in $@; do
+    if [ "$arg" == "-dumpmachine" ] || [ "$arg" == "-dumpmachinefull" ]; then
+        cmd_out="$(cl 2>&1)"
+        cmd_out_parts=($cmd_out)
+        msvc="msvc"
+        if [ "$arg" == "-dumpmachinefull" ]; then
+            msvc="$msvc${cmd_out_parts[6]}"
+        fi
+        arch="$(echo ${cmd_out_parts[8]} | awk '{print tolower($0)}')"
+        output="pc-windows-$msvc"
+        if [ "$arch" = "x64" ]; then
+            output="x86_64-$output"
+        elif [ "$arch" = "x86" ]; then
+            output="i386-$output"
+        elif [ "$arch" = "arm64" ]; then
+            output="aarch64-$output"
+        else
+            output="armv7-$output"
+        fi
+        echo $output
+        exit 0
+    fi
+done
+
 # prog specifies the program that should be run cl.exe
 prog=cl
 # opts specifies the command line to pass to the MSVC program

--- a/cccl
+++ b/cccl
@@ -39,10 +39,25 @@ case $MACHTYPE in
         ;;
 esac
 
+# prog specifies the program that should be run cl.exe
+prog=cl
+# opts specifies the command line to pass to the MSVC program
+clopt=("${slash}nologo")
+linkopt=("${slash}link")
+debug=
+# gotparam is 0 if we didn't ever see a param, in which case we show usage()
+gotparam=
+muffle=
+verbose=
+shared_index=-1
+
+# "dumpmachine" is a CC command-line argument to show the compiler's host triplet
+# "cccl" will follow "clang"'s MSVC "dumpmachine" output
+# "dumpmachinefull" is added as well to show the full MSVC version
 # Process the "dumpmachine"/"dumpmachinefull" arguments first, if they exist, and exit gracefully
 for arg in $@; do
     if [[ $arg =~ ^-dumpmachine(full)?$ ]]; then
-        cl_output_parts=($(cl 2>&1))
+        cl_output_parts=($($prog 2>&1))
 
         msvc="msvc"
         if [ "$arg" == "-dumpmachinefull" ]; then
@@ -77,18 +92,6 @@ for arg in $@; do
         exit 0
     fi
 done
-
-# prog specifies the program that should be run cl.exe
-prog=cl
-# opts specifies the command line to pass to the MSVC program
-clopt=("${slash}nologo")
-linkopt=("${slash}link")
-debug=
-# gotparam is 0 if we didn't ever see a param, in which case we show usage()
-gotparam=
-muffle=
-verbose=
-shared_index=-1
 
 processargs()
 {


### PR DESCRIPTION
Recreated the pull request from https://github.com/swig/cccl/pull/14, as I needed to change the source branch in my fork.

Add two new command-line arguments to get the target machine's triplet, by parsing the command-line output of `cl`:
    * `dumpmachine`, which is to get the base machine triplet in the format `{arch}-pc-windows-msvc`, where `{arch}` is the target archetecture. If the target architecture is ARM or X86, `{arch}` will be set to `armv7` or `i386`, respectfully (since there are many ARM or X86 archetectures). `dumpmachine` is similer to that of `gcc`/`clang`'s command of the same name.
    * `dumpmachinefull`, which has the same output as `dumpmachine`, except it is post-fixed by the full MSVC version being used. In other words, the command-line argument has the following format `{arch}-pc-windows-msvc{msvcver}`, where `{arch}` is the target archetecture and `{msvcver}` is the MSVC version.

These arguments precede any other arguments passed to `cccl`, and if `dumpmachine`/`dumpmachinefull` is processed, it will print the target triplet and exit succefully (the first of `dumpmachine` or `dumpmachinefull` will be processed).